### PR TITLE
Add ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,17 +16,16 @@ jobs:
             - radio-clerk
   deploy:
     docker:
-        - image: ruby:2.5
+        - image: circleci/golang:1.10.4
     working_directory: /tmp
     steps:
       - attach_workspace:
-          at: /tmp/workspace
+          at: ./artifacts
       - run:
-          name: Setup Environment Variables
+          name: "Publish Release on GitHub"
           command: |
-            echo 'export TRAVIS_TAG="$CIRCLE_SHA1"' >> $BASH_ENV
-      - run: gem install dpl
-      - run: dpl --provider=releases --repo=bottleneckco/radio-clerk "--release-number=$CIRCLE_BRANCH-$CIRCLE_SHA1-$CIRCLE_BUILD_NUM" --api-key=$GITHUB_TOKEN --file=radio-clerk --prerelease
+            go get github.com/tcnksm/ghr
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete "${CIRCLE_SHA1}-${CIRCLE_BUILD_NUM}" ./artifacts/
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.9
-    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    working_directory: /go/src/github.com/$ORG_NAME/$REPO_NAME
     steps:
       - checkout
 
       # specify any bash command here prefixed with `run: `
       - run: go get -u github.com/golang/dep/cmd/dep
       - run: dep ensure -vendor-only
-      - run: go build -a -o {{REPO_NAME}} .
+      - run: go build -a -o $REPO_NAME .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.9
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go get -u github.com/golang/dep/cmd/dep
+      - run: dep ensure -vendor-only
+      - run: go build -a -o {{REPO_NAME}} .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,18 @@ jobs:
       - checkout
 
       # specify any bash command here prefixed with `run: `
-      - run: pwd
       - run: dep ensure -vendor-only
-      - run: go build -a -o $CIRCLE_PROJECT_REPONAME .
+      - run: go build -a -o radio-clerk .
+      - persist_to_workspace:
+          root: .
+          paths:
+            - radio-clerk
+  deploy:
+    docker:
+        - image: ruby:2.5
+    working_directory: /tmp
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: gem install dpl
+      - run: dpl --provider=releases --repo=bottleneckco/radio-clerk "--release-number=$CIRCLE_BRANCH-$CIRCLE_SHA1-$CIRCLE_BUILD_NUM" --api-key=$GITHUB_TOKEN --file=radio-clerk --prerelease

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,5 +9,6 @@ jobs:
           path: /go/src/github.com/$CIRCLE_PROJECT_USERNAME
 
       # specify any bash command here prefixed with `run: `
+      - run: pwd
       - run: dep ensure -vendor-only
       - run: go build -a -o $CIRCLE_PROJECT_REPONAME .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,3 +23,14 @@ jobs:
           at: /tmp/workspace
       - run: gem install dpl
       - run: dpl --provider=releases --repo=bottleneckco/radio-clerk "--release-number=$CIRCLE_BRANCH-$CIRCLE_SHA1-$CIRCLE_BUILD_NUM" --api-key=$GITHUB_TOKEN --file=radio-clerk --prerelease
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: add-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - run:
+          name: Setup Environment Variables
+          command: |
+            echo 'export TRAVIS_TAG="$CIRCLE_SHA1"' >> $BASH_ENV
       - run: gem install dpl
       - run: dpl --provider=releases --repo=bottleneckco/radio-clerk "--release-number=$CIRCLE_BRANCH-$CIRCLE_SHA1-$CIRCLE_BUILD_NUM" --api-key=$GITHUB_TOKEN --file=radio-clerk --prerelease
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,7 @@ jobs:
       - image: circleci/golang:1.10.4
     working_directory: /go/src/github.com/bottleneckco/radio-clerk
     steps:
-      - checkout:
-          path: /go/src/github.com/bottleneckco
+      - checkout
 
       # specify any bash command here prefixed with `run: `
       - run: pwd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.10.4
-    working_directory: /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+    working_directory: /go/src/github.com/bottleneckco/radio-clerk
     steps:
       - checkout:
-          path: /go/src/github.com/$CIRCLE_PROJECT_USERNAME
+          path: /go/src/github.com/bottleneckco
 
       # specify any bash command here prefixed with `run: `
       - run: pwd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.9
-    working_directory: /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+      - image: circleci/golang:1.10.4
     steps:
+      - run: mkdir -p /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+      - run: cd /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
       - checkout
 
       # specify any bash command here prefixed with `run: `
-      - run: go get -u github.com/golang/dep/cmd/dep
       - run: dep ensure -vendor-only
       - run: go build -a -o $CIRCLE_PROJECT_REPONAME .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,15 @@ jobs:
 
       # specify any bash command here prefixed with `run: `
       - run: dep ensure -vendor-only
-      - run: go build -a -o radio-clerk .
+      - run: go build -a -o radio-clerk-linux64 .
+      - run: env GOOS=linux GOARCH=386 go build -a -o radio-clerk-linux32 .
+      - run: env GOOS=windows GOARCH=386 go build -a -o radio-clerk-win32.exe .
+      - run: env GOOS=windows GOARCH=amd64 go build -a -o radio-clerk-win64.exe .
+      - run: env GOOS=darwin GOARCH=amd64 go build -a -o radio-clerk-darwin .
       - persist_to_workspace:
           root: .
           paths:
-            - radio-clerk
+            - radio-clerk-*
   deploy:
     docker:
         - image: circleci/golang:1.10.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,4 +40,4 @@ workflows:
             - build
           filters:
             branches:
-              only: add-ci
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.9
-    working_directory: /go/src/github.com/$ORG_NAME/$REPO_NAME
+    working_directory: /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
     steps:
       - checkout
 
       # specify any bash command here prefixed with `run: `
       - run: go get -u github.com/golang/dep/cmd/dep
       - run: dep ensure -vendor-only
-      - run: go build -a -o $REPO_NAME .
+      - run: go build -a -o $CIRCLE_PROJECT_REPONAME .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     working_directory: /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
     steps:
       - checkout:
-        path: /go/src/github.com/$CIRCLE_PROJECT_USERNAME
+          path: /go/src/github.com/$CIRCLE_PROJECT_USERNAME
 
       # specify any bash command here prefixed with `run: `
       - run: dep ensure -vendor-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.10.4
+    working_directory: /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
     steps:
-      - run: mkdir -p /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-      - run: cd /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-      - checkout
+      - checkout:
+        path: /go/src/github.com/$CIRCLE_PROJECT_USERNAME
 
       # specify any bash command here prefixed with `run: `
       - run: dep ensure -vendor-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: gem install dpl
-      - run: dpl --provider=releases --repo=bottleneckco/radio-clerk "--release-number=$CIRCLE_BRANCH-$CIRCLE_SHA1-$CIRCLE_BUILD_NUM" --api-key=$GITHUB_TOKEN --file=radio-clerk
+      - run: dpl --provider=releases --repo=bottleneckco/radio-clerk "--release-number=$CIRCLE_BRANCH-$CIRCLE_SHA1-$CIRCLE_BUILD_NUM" --api-key=$GITHUB_TOKEN --file=radio-clerk --prerelease
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: gem install dpl
-      - run: dpl --provider=releases --repo=bottleneckco/radio-clerk "--release-number=$CIRCLE_BRANCH-$CIRCLE_SHA1-$CIRCLE_BUILD_NUM" --api-key=$GITHUB_TOKEN --file=radio-clerk --prerelease
+      - run: dpl --provider=releases --repo=bottleneckco/radio-clerk "--release-number=$CIRCLE_BRANCH-$CIRCLE_SHA1-$CIRCLE_BUILD_NUM" --api-key=$GITHUB_TOKEN --file=radio-clerk
 workflows:
   version: 2
   build-and-deploy:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # radio-clerk
+[![CircleCI](https://circleci.com/gh/bottleneckco/radio-clerk/tree/master.svg?style=svg)](https://circleci.com/gh/bottleneckco/radio-clerk/tree/master)
 Discord music bot, written in Golang
 
 ### Requirements


### PR DESCRIPTION
# Purpose
This PR adds support for CircleCI continuous integration. Specifically, it attempts to build the Go application and then cross-compile for multiple OS platforms and upload the binaries to GitHub Releases.